### PR TITLE
Fix JSON decode error on successful requests

### DIFF
--- a/APIs/SweccAPI.py
+++ b/APIs/SweccAPI.py
@@ -118,6 +118,10 @@ class SweccAPI:
             f"{self.url}/engagement/attendance/attend", headers=self.headers, json=data
         )
 
+        # Success
+        if response.status_code == 201:
+            return response.status_code, {}
+
         try:
             received_data = response.json()
             return response.status_code, received_data


### PR DESCRIPTION
The backend doesn't return a body for successful requests, so, when attempting to parse the response to a well-formed response, a `JSONDecodeError` was being thrown. 

This shouldn't be happening because the request was well-formed and valid, so this PR fixes that.