### PR TITLE
Change leaderboard URL to leaderboard.swecc.org

### DIFF
--- a/slash_commands/misc.py
+++ b/slash_commands/misc.py
@@ -115,8 +115,8 @@ async def leetcode_leaderboard(ctx: discord.Interaction, order: str = "total"):
         embed.add_field(name="", value="\n\n".join(leaderboard_text[5:]), inline=False)
 
     embed.add_field(
-        name="🔗 Want to join the leaderboard? Sign up below",
-        value=f"[interview.swecc.org](https://interview.swecc.org)",
+        name="🔗 View the full leaderboard below!",
+        value=f"[leaderboard.swecc.org](https://leaderboard.swecc.org)",
         inline=False,
     )
 
@@ -156,8 +156,8 @@ async def github_leaderboard(ctx: discord.Interaction, order: str = "commits"):
         embed.add_field(name="", value="\n\n".join(leaderboard_text[5:]), inline=False)
 
     embed.add_field(
-        name="🔗 Want to join the leaderboard? Sign up below",
-        value=f"[interview.swecc.org](https://interview.swecc.org)",
+        name="🔗 View the full leaderboard below!",
+        value=f"[leaderboard.swecc.org](https://leaderboard.swecc.org)",
         inline=False,
     )
 


### PR DESCRIPTION
## Changes
- Change leaderboard URL to link to [SWECC's leaderboard](https://leaderboard.swecc.org) instead of the mock interview platform

## Related Issues
- Closes #31 