### PR TITLE
Stop pinging in deleted logs

### DIFF
--- a/admin/filter.py
+++ b/admin/filter.py
@@ -32,6 +32,6 @@ async def filter_message(message, bot_context):
                         
                         view = TimeoutActionView(member, bot_context)
                         channel = message.guild.get_channel(bot_context.transcripts_channel)
-                        await channel.send(log_message)
+                        await channel.send(log_message, allowed_mentions=discord.AllowedMentions.none)
                         await channel.send("How should we handle it?", view=view)
                         break


### PR DESCRIPTION
This stops the content of deleted messages from pinging everyone. This might also be good to do for most other message send instances for the bot to avoid people exploiting it to ping everyone.

Also we should probably add type annotations sometime.